### PR TITLE
Prevents the formatter from inserting spaces between `&&` and `||`.

### DIFF
--- a/client/src/formatter.ts
+++ b/client/src/formatter.ts
@@ -145,7 +145,8 @@ export class Formatter
         let text = this.doc.lineAt(line).text;
         let empties: Gap[] = [];
 
-        const reg = /((?:(?:\+\+|--)?[_0-9a-zA-Z]+(?:\+\+|--)?)|(?:(?:(?:\+|-|\*|\/|%|=|&|\||\^|<<|>>)=?)|(?:<|>|<=|>=|==|\!=|\|\||&&)|(?:\.|\?|\:|~|,|;|\(|\)|\[|\]|{|}))|(?:"(?:[^\\"]|\\\S|\\")*"))(\s+)?/g;
+        const reg = /((?:(?:\+\+|--)?[_0-9a-zA-Z]+(?:\+\+|--)?)|(?:(?:<|>|<=|>=|==|\!=|\|\||&&)|(?:(?:\+|-|\*|\/|%|=|&|\||\^|<<|>>)=?)|(?:\.|\?|\:|~|,|;|\(|\)|\[|\]|{|}))|(?:"(?:[^\\"]|\\\S|\\")*"))(\s+)?/g;
+
         let headerSpace = /\s+/.exec(text);
         empties.push(new Gap(this.doc, new Position(line, 0), new Position(line, headerSpace ? headerSpace[0].length : 0)));
         for (let match = reg.exec(text); match; match = reg.exec(text))

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "Programming Languages"
     ],
     "scripts": {
+        "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
         "vscode:prepublish": "cd client && npm run update-vscode && cd .. && npm run build",
         "build:client": "tsc -p ./client/tsconfig.json",
         "build:server": "tsc -p ./server/tsconfig.json",


### PR DESCRIPTION
I've changed the regexp in the splitGap method so that it evaulates double `&&` and `||` before evaluating single `&` and `|` characters.

I've also added a postinstall script in the root package.json to make it simplier to install dependencies for client and server, just like the [Microsoft Example](https://github.com/Microsoft/vscode-extension-samples/blob/master/lsp-multi-server-sample/)